### PR TITLE
Avoid disabling Firefox XML pretty printing

### DIFF
--- a/extension/inject.js
+++ b/extension/inject.js
@@ -215,12 +215,18 @@ var inject = '('+function() {
   }
 }+')();';
 
-document.addEventListener('DOMContentLoaded', function() {
-    var script = document.createElement('script');
-    script.textContent = inject;
-    (document.head||document.documentElement).appendChild(script);
-    script.parentNode.removeChild(script);
-});
+// Exclude non-(X)HTML documents to avoid breaking Firefox XML pretty printing
+// See https://bugzilla.mozilla.org/1605657
+if (document.contentType === 'text/html' ||
+    document.contentType === 'application/xhtml+xml' ||
+    document.documentElement.namespaceURI === 'http://www.w3.org/1999/xhtml') {
+    document.addEventListener('DOMContentLoaded', function() {
+        var script = document.createElement('script');
+        script.textContent = inject;
+        (document.head||document.documentElement).appendChild(script);
+        script.parentNode.removeChild(script);
+    });
+}
 
 if (typeof browser === 'undefined') {
     browser = chrome;


### PR DESCRIPTION
Firefox displays XML documents with unsupported namespaces that lack XSL stylesheets using `nsXMLPrettyPrinter` which produces an interactive tree view of the XML content.  If any content is appended, the [pretty printing is disabled] because it [no longer matches the modified DOM]. This was modified in [Bug 1605657] to exclude changes made by by extensions during document_start, but it does not exclude changes made later (e.g. on DOMContentLoaded as this extension does).

Rather than injecting the &lt;script&gt; during document_start, this pull request takes the [approach of React DeveloperTools] and only injects scripts for (X)HTML documents.  Note that this pull request additionally recognizes XHTML documents served as application/xml or text/xml by checking the namespace of the document element.  Even with this additional coverage, it does not recognize embedded XHTML (such as &lt;xhtml:video&gt; in SVG) or other exotic document types.  DOM traversal could be added to cover more of these cases, if desired.

[pretty printing is disabled]: https://searchfox.org/mozilla-central/rev/692215ac0263906577c610a4ebd32822834bd398/dom/xml/nsXMLPrettyPrinter.cpp#152
[no longer matches the modified DOM]: https://bugzilla.mozilla.org/show_bug.cgi?id=1605657#c26
[Bug 1605657]: https://bugzilla.mozilla.org/1605657
[approach of React DeveloperTools]: https://github.com/facebook/react/pull/1773

Thanks for considering,
Kevin